### PR TITLE
Added all versions up to Ruby 3.4 to the CI matrix.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
         rails: ['6.1', '7.1']
     env:
       BUNDLE_GEMFILE: 'gemfiles/rails_${{ matrix.rails }}.gemfile'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### next
 
-* TODO: Replace this bullet point with an actual description of a change.
+* Added all versions up to Ruby 3.4 to the CI matrix (#9)
 
 ### 1.6.1 (17 January 2025)
 

--- a/keyless.gemspec
+++ b/keyless.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 6.1'
   spec.add_dependency 'httparty', '>= 0.21'
   spec.add_dependency 'jwt', '~> 2.6'
+  spec.add_dependency 'mutex_m', '~> 0.3.0'
   spec.add_dependency 'recursive-open-struct', '~> 2.0'
   spec.add_dependency 'zeitwerk', '~> 2.6'
 end


### PR DESCRIPTION
See: https://github.com/hausgold/env/issues/308