### PR TITLE
Switched to the http gem and added retries for fetching RSA public keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### next
 
-* TODO: Replace this bullet point with an actual description of a change.
+* Switched from `httparty` to the `http` gem and added support for retries on
+  the RSA remote fetching (5 times by default) (#18)
 
 ### 2.2.0 (2 December 2025)
 

--- a/keyless.gemspec
+++ b/keyless.gemspec
@@ -36,9 +36,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.2'
 
   spec.add_dependency 'activesupport', '>= 7.1'
-  spec.add_dependency 'httparty', '>= 0.21'
+  spec.add_dependency 'http', '~> 5.3'
   spec.add_dependency 'jwt', '>= 2.6'
   spec.add_dependency 'mutex_m', '>= 0.3'
   spec.add_dependency 'recursive-open-struct', '~> 2.0'
+  spec.add_dependency 'retries', '>= 0.0.5'
   spec.add_dependency 'zeitwerk', '~> 2.6'
 end

--- a/lib/keyless.rb
+++ b/lib/keyless.rb
@@ -14,7 +14,8 @@ require 'jwt'
 require 'recursive-open-struct'
 require 'singleton'
 require 'openssl'
-require 'httparty'
+require 'http'
+require 'retries'
 
 # The JWT authentication concern.
 module Keyless

--- a/lib/keyless/configuration.rb
+++ b/lib/keyless/configuration.rb
@@ -64,6 +64,10 @@ module Keyless
     # here.
     config_accessor(:rsa_public_key_url) { nil }
 
+    # When the remote (HTTP/HTTPS) fetching failed, how many times to retry the
+    # operation.
+    config_accessor(:rsa_public_key_fetch_retries) { 5 }
+
     # You can preconfigure the {RsaPublickey} class to enable/disable
     # caching. For a remote public key location it is handy to cache the
     # result for some time to keep the traffic low to this resource server.

--- a/spec/fixtures/cassettes/Keyless_RsaPublicKey/_fetch_encoded_key/with_remote_URL/raises_a_FetchError_when_not_successful.yml
+++ b/spec/fixtures/cassettes/Keyless_RsaPublicKey/_fetch_encoded_key/with_remote_URL/raises_a_FetchError_when_not_successful.yml
@@ -2,45 +2,152 @@
 http_interactions:
 - request:
     method: get
-    uri: https://httpstat.us/502
+    uri: https://httpco.de/502
     body:
-      encoding: US-ASCII
+      encoding: ASCII-8BIT
       string: ''
     headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
+      Connection:
+      - close
+      Host:
+      - httpco.de
       User-Agent:
-      - Ruby
+      - http.rb/5.3.1
   response:
     status:
       code: 502
       message: Bad Gateway
     headers:
-      Cache-Control:
-      - private
-      Content-Length:
-      - '15'
+      Date:
+      - Mon, 15 Dec 2025 15:17:43 GMT
       Content-Type:
       - text/plain; charset=utf-8
-      Server:
-      - Microsoft-IIS/10.0
-      X-Aspnetmvc-Version:
-      - '5.1'
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Aspnet-Version:
-      - 4.0.30319
-      X-Powered-By:
-      - ASP.NET
-      Set-Cookie:
-      - ARRAffinity=d28d08589b40450da29f4b2b440a8999dc4a99e3f16179b8cb4261db712aed16;Path=/;HttpOnly;Domain=httpstat.us
-      Date:
-      - Thu, 14 Feb 2019 11:05:31 GMT
+      Content-Length:
+      - '11'
+      Connection:
+      - close
     body:
       encoding: UTF-8
-      string: 502 Bad Gateway
-    http_version: 
-  recorded_at: Thu, 14 Feb 2019 11:05:32 GMT
-recorded_with: VCR 3.0.3
+      string: Bad Gateway
+  recorded_at: Mon, 15 Dec 2025 15:17:43 GMT
+- request:
+    method: get
+    uri: https://httpco.de/502
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - httpco.de
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 502
+      message: Bad Gateway
+    headers:
+      Date:
+      - Mon, 15 Dec 2025 15:17:43 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '11'
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: Bad Gateway
+  recorded_at: Mon, 15 Dec 2025 15:17:43 GMT
+- request:
+    method: get
+    uri: https://httpco.de/502
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - httpco.de
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 502
+      message: Bad Gateway
+    headers:
+      Date:
+      - Mon, 15 Dec 2025 15:17:44 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '11'
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: Bad Gateway
+  recorded_at: Mon, 15 Dec 2025 15:17:44 GMT
+- request:
+    method: get
+    uri: https://httpco.de/502
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - httpco.de
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 502
+      message: Bad Gateway
+    headers:
+      Date:
+      - Mon, 15 Dec 2025 15:17:45 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '11'
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: Bad Gateway
+  recorded_at: Mon, 15 Dec 2025 15:17:45 GMT
+- request:
+    method: get
+    uri: https://httpco.de/502
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - httpco.de
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 502
+      message: Bad Gateway
+    headers:
+      Date:
+      - Mon, 15 Dec 2025 15:17:46 GMT
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '11'
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: Bad Gateway
+  recorded_at: Mon, 15 Dec 2025 15:17:46 GMT
+recorded_with: VCR 6.3.1

--- a/spec/keyless/rsa_public_key_spec.rb
+++ b/spec/keyless/rsa_public_key_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Keyless::RsaPublicKey do
       end
 
       it 'raises a FetchError when not successful', :vcr do
-        instance.url = 'https://httpstat.us/502'
+        instance.url = 'https://httpco.de/502'
         expect { instance.fetch_encoded_key }.to \
           raise_error(Keyless::RsaPublicKey::FetchError,
                       /502 Bad Gateway/)


### PR DESCRIPTION
See: 
* https://appsignal.com/talocasa-gmbh/sites/60d9a4fa14ad664af5dab881/exceptions/incidents/419/samples/timestamp/2025-12-15T08:47:33Z
* https://github.com/hausgold/env/issues/344
* https://github.com/hausgold/env/issues/328

---

Error: Keyless::RsaPublicKey::FetchError
Message: `#<HTTParty::Response:0x9090 @response=#<Net::HTTPBadGateway 502 Bad Gateway readbody=true>>`
Backtrace:

```
lib/keyless/rsa_public_key.rb:64 Keyless::RsaPublicKey#fetch_encoded_key
lib/keyless/rsa_public_key.rb:46 block in Keyless::RsaPublicKey#fetch
```